### PR TITLE
Disable `default-features` for chrono dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 travis-ci = { repository = "felipenoris/bdays" }
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 bencher = "0.1"


### PR DESCRIPTION
Default features for chrono dependency includes `oldtime`, which loads very old version of `time` crate into scope.
This library doesn't seem to rely on that feature, so it should be safe to remove it. User can add it back, if they need.