### PR TITLE
Fix links in doc

### DIFF
--- a/src/calendars/brazil.rs
+++ b/src/calendars/brazil.rs
@@ -77,7 +77,7 @@ impl<T: Datelike + Copy + PartialOrd> HolidayCalendar<T> for BRSettlement {
     }
 }
 
-/// B3 Exchange holidays (http://www.b3.com.br).
+/// B3 Exchange holidays (<https://www.b3.com.br>).
 pub struct BrazilExchange;
 
 impl<T: Datelike + Copy + PartialOrd> HolidayCalendar<T> for BrazilExchange {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! * `bdays::calendars::WeekendsOnly` : accounts only weekends
 //! * `bdays::calendars::brazil::BRSettlement` : Brazilian banking holidays
-//! * `bdays::calendars::brazil::BrazilExchange` : B3 Exchange holidays (http://www.b3.com.br)
+//! * `bdays::calendars::brazil::BrazilExchange` : B3 Exchange holidays (<https://www.b3.com.br>)
 //! * `bdays::calendars::us::USSettlement` : United States federal holidays
 //!
 //! # Usage


### PR DESCRIPTION
When building the docs, cargo throws some warnings:

```
warning: this URL is not a hyperlink
  --> src/lib.rs:15:74
   |
15 | //! * `bdays::calendars::brazil::BrazilExchange` : B3 Exchange holidays (http://www.b3.com.br)
   |                                                                          ^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<http://www.b3.com.br>`
   |
   = note: bare URLs are not automatically turned into clickable links
   = note: `#[warn(rustdoc::bare_urls)]` on by default

warning: this URL is not a hyperlink
  --> src/calendars/brazil.rs:80:27
   |
80 | /// B3 Exchange holidays (http://www.b3.com.br).
   |                           ^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<http://www.b3.com.br>`
   |
   = note: bare URLs are not automatically turned into clickable links
```

I implemented cargo's suggestions and changed the protocol from http to https.