### PR TITLE
Add November 20th to brazilian holidays

### DIFF
--- a/src/calendars/brazil.rs
+++ b/src/calendars/brazil.rs
@@ -25,6 +25,9 @@ fn is_brazilian_national_holiday<T: Datelike + Copy + PartialOrd>(date: T) -> bo
             // Proclamacao da Republica
             ((mm == 11) && (dd == 15))
             ||
+            // Dia Nacional de Zumbi e da Consciência Negra
+            ((mm == 11) && (dd == 20) && (yy > 2023))
+            ||
             // Natal
             ((mm == 12) && (dd == 25))
         {


### PR DESCRIPTION
Starting this year (2024), November 20th becomes a national holiday in Brazil (National Zumbi and Black Awareness day).
This pull request adds this date to the brazilian holidays, affecting both `BRSettlement` and `BrazilExchange` calendars.